### PR TITLE
Fix behavior when Flush is called several times concurrently.

### DIFF
--- a/logdna.go
+++ b/logdna.go
@@ -87,7 +87,10 @@ func (c *Client) Log(t time.Time, msg string) {
 		Line:      msg,
 		File:      c.config.LogFile,
 	}
+
+	c.flushLock.Lock()
 	c.payload.Lines = append(c.payload.Lines, logLine)
+	c.flushLock.Unlock()
 
 	if c.Size() >= c.config.FlushLimit {
 		c.Flush()

--- a/logdna.go
+++ b/logdna.go
@@ -1,11 +1,14 @@
 package logdna
 
-import "bytes"
-import "encoding/json"
-import "net/http"
-import "net/url"
-import "strconv"
-import "time"
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+)
 
 // IngestBaseURL is the base URL for the LogDNA ingest API.
 const IngestBaseURL = "https://logs.logdna.com/logs/ingest"
@@ -23,9 +26,10 @@ type Config struct {
 
 // Client is a client to the LogDNA logging service.
 type Client struct {
-	config  Config
-	payload payloadJSON
-	apiURL  url.URL
+	config    Config
+	payload   payloadJSON
+	apiURL    url.URL
+	flushLock *sync.Mutex
 }
 
 // logLineJSON represents a log line in the LogDNA ingest API JSON payload.
@@ -65,6 +69,7 @@ func NewClient(cfg Config) *Client {
 	client.apiURL = makeIngestURL(cfg)
 
 	client.config = cfg
+	client.flushLock = &sync.Mutex{}
 
 	return &client
 }
@@ -75,10 +80,6 @@ func NewClient(cfg Config) *Client {
 //
 // Flush is called automatically if we reach the client's flush limit.
 func (c *Client) Log(t time.Time, msg string) {
-	if c.Size() == c.config.FlushLimit {
-		c.Flush()
-	}
-
 	// Ingest API wants timestamp in milliseconds so we need to round timestamp
 	// down from nanoseconds.
 	logLine := logLineJSON{
@@ -87,6 +88,10 @@ func (c *Client) Log(t time.Time, msg string) {
 		File:      c.config.LogFile,
 	}
 	c.payload.Lines = append(c.payload.Lines, logLine)
+
+	if c.Size() >= c.config.FlushLimit {
+		c.Flush()
+	}
 }
 
 // Size returns the number of lines waiting to be sent.
@@ -100,6 +105,10 @@ func (c *Client) Flush() error {
 	if c.Size() == 0 {
 		return nil
 	}
+
+	//prevent concurrent Flush()es from stepping on one another
+	c.flushLock.Lock()
+	defer c.flushLock.Unlock()
 
 	jsonPayload, err := json.Marshal(c.payload)
 	if err != nil {


### PR DESCRIPTION
I noticed that when Flush was called from multiple goroutines
simultaneously, we'd occasionally see repeated log lines as the
LogDNA client would send the same payload twice. This is unlikely
when using the DefaultFlushLimit, but we'd encounter it when we
turned the FlushLimit down to 1. I fixed this by adding a mutex
to the Client such that only one Flush can occur at once for each
Client.

Additionally, I moved the check to see if the FlushLimit had been
reached to the end of Log(), so that if FlushLimit is 1, each
message is sent immediately as it is Logged.